### PR TITLE
Fix errors for mitamae

### DIFF
--- a/mrblib/itamae/plugin/resource/pip.rb
+++ b/mrblib/itamae/plugin/resource/pip.rb
@@ -1,4 +1,4 @@
-module MItamae
+module ::MItamae
   module Plugin
     module Resource
       class Pip < ::MItamae::Resource::Base

--- a/mrblib/itamae/plugin/resource/pip.rb
+++ b/mrblib/itamae/plugin/resource/pip.rb
@@ -1,7 +1,7 @@
 module MItamae
   module Plugin
     module Resource
-      class Pip < MItamae::Resource::Base
+      class Pip < ::MItamae::Resource::Base
         define_attribute :action, default: :install
         define_attribute :pip_binary, type: [String, Array], default: 'pip'
         define_attribute :package_name, type: String, default_name: true

--- a/mrblib/itamae/plugin/resource_executor/pip.rb
+++ b/mrblib/itamae/plugin/resource_executor/pip.rb
@@ -2,7 +2,7 @@ module ::MItamae
   module Plugin
     module ResourceExecutor
       class Pip < ::MItamae::ResourceExecutor::Base
-        def apply(current, desired)
+        def apply
           if desired.installed
             if current.installed
               if desired.version && current.version != desired.version

--- a/mrblib/itamae/plugin/resource_executor/pip.rb
+++ b/mrblib/itamae/plugin/resource_executor/pip.rb
@@ -1,7 +1,7 @@
 module MItamae
   module Plugin
     module ResourceExecutor
-      class Pip < MItamae::ResourceExecutor::Base
+      class Pip < ::MItamae::ResourceExecutor::Base
         def apply(current, desired)
           if desired.installed
             if current.installed

--- a/mrblib/itamae/plugin/resource_executor/pip.rb
+++ b/mrblib/itamae/plugin/resource_executor/pip.rb
@@ -1,4 +1,4 @@
-module MItamae
+module ::MItamae
   module Plugin
     module ResourceExecutor
       class Pip < ::MItamae::ResourceExecutor::Base


### PR DESCRIPTION
This plugin doesn't work in mitamae v1.4.1 because of below errors.

- uninitialized constant #<Class:0x7feee680bbc0>::MItamae::Resource (NameError)
- undefined method 'pip' for #<MItamae::RecipeContext:0x7f9e968db3a0> (NoMethodError)
- ArgumentError: 'apply': wrong number of arguments (0 for 2)


