### PR TITLE
Disable pip version check by default

### DIFF
--- a/lib/itamae/plugin/resource/pip.rb
+++ b/lib/itamae/plugin/resource/pip.rb
@@ -5,7 +5,7 @@ module Itamae
     module Resource
       class Pip < Itamae::Resource::Base
         define_attribute :action, default: :install
-        define_attribute :pip_binary, type: [String, Array], default: 'pip'
+        define_attribute :pip_binary, type: [String, Array], default: ['pip', '--disable-pip-version-check']
         define_attribute :package_name, type: String, default_name: true
         define_attribute :version, type: String, default: false
 


### PR DESCRIPTION
## Description
`pip` will perform a version check by default, which appends a warning message like
> You are using pip version 9.0.3, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.

to the output.

This message breaks the parsing of package requirements(https://github.com/katsyoshi/itamae-plugin-resource-pip/blob/master/lib/itamae/plugin/resource/pip.rb#L60).

As version check is useless I appended an option to the default command to suppress the warning message.