### PR TITLE
Implement options attribute for resource to pass arbitrary arguments to pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ require 'itamae/plugin/resource/pip'
 pip "tornado" do
   pip_binary "/home/user/.pyenv/shims/pip"
   version "4.1"
+  options '--user'
 end
 ```
 

--- a/lib/itamae/plugin/resource/pip.rb
+++ b/lib/itamae/plugin/resource/pip.rb
@@ -7,6 +7,7 @@ module Itamae
         define_attribute :action, default: :install
         define_attribute :pip_binary, type: [String, Array], default: ['pip', '--disable-pip-version-check']
         define_attribute :package_name, type: String, default_name: true
+        define_attribute :options, type: [String, Array], default: :auto
         define_attribute :version, type: String, default: false
 
         def pre_action
@@ -66,6 +67,8 @@ module Itamae
 
         def build_pip_install_command
           cmd = [*Array(attributes.pip_binary), 'install']
+          cmd << attributes.options if attributes.options
+
           if attributes.version
             cmd << "#{attributes.package_name}==#{attributes.version}"
           else

--- a/mrblib/itamae/plugin/resource/pip.rb
+++ b/mrblib/itamae/plugin/resource/pip.rb
@@ -5,6 +5,7 @@ module ::MItamae
         define_attribute :action, default: :install
         define_attribute :pip_binary, type: [String, Array], default: 'pip'
         define_attribute :package_name, type: String, default_name: true
+        define_attribute :options, type: [String, Array], default: :auto
         define_attribute :version, type: String, default: false
 
         self.available_actions = [:install, :uninstall, :upgrade]

--- a/mrblib/itamae/plugin/resource_executor/pip.rb
+++ b/mrblib/itamae/plugin/resource_executor/pip.rb
@@ -55,6 +55,8 @@ module ::MItamae
 
         def install!
           cmd = [*Array(attributes.pip_binary), 'install']
+          cmd << attributes.options if attributes.options
+
           if attributes.version
             cmd << "#{attributes.package_name}==#{attributes.version}"
           else
@@ -66,6 +68,8 @@ module ::MItamae
 
         def uninstall!
           cmd = [*Array(attributes.pip_binary), 'uninstall']
+          cmd << attributes.options if attributes.options
+
           if attributes.version
             cmd << "#{attributes.package_name}==#{attributes.version}"
           else


### PR DESCRIPTION
This PR adds an optional `options` attribute to pass arbitrary arguments to pip, e.g. `--user` or `--prefix`.