### PR TITLE
Do not set version to false by default

### DIFF
--- a/lib/itamae/plugin/resource/pip.rb
+++ b/lib/itamae/plugin/resource/pip.rb
@@ -8,7 +8,7 @@ module Itamae
         define_attribute :pip_binary, type: [String, Array], default: ['pip', '--disable-pip-version-check']
         define_attribute :package_name, type: String, default_name: true
         define_attribute :options, type: [String, Array], default: :auto
-        define_attribute :version, type: String, default: false
+        define_attribute :version, type: String
 
         def pre_action
           case @current_action

--- a/mrblib/itamae/plugin/resource/pip.rb
+++ b/mrblib/itamae/plugin/resource/pip.rb
@@ -6,7 +6,7 @@ module ::MItamae
         define_attribute :pip_binary, type: [String, Array], default: 'pip'
         define_attribute :package_name, type: String, default_name: true
         define_attribute :options, type: [String, Array], default: :auto
-        define_attribute :version, type: String, default: false
+        define_attribute :version, type: String
 
         self.available_actions = [:install, :uninstall, :upgrade]
       end


### PR DESCRIPTION
If we are setting `version` to `false` by default packages without an explicit version will always show up as a delta:

```
DEBUG :         pip[keyring] installed will not change (current value is 'true')
 INFO :         pip[keyring] version will change from '13.1.0' to 'false'
```

However, if we do not set `version` to any default value (M)Itamae is smart enough to realize it doesn't need to change the version:

```
DEBUG :         pip[keyring] installed will not change (current value is 'true')
DEBUG :         pip[keyring] version will not change (current value is '13.1.0')
```

Since we aren't checking the currently installed version it has no impact on upgrades.