### PR TITLE
fix error for options attribute

### DIFF
--- a/lib/itamae/plugin/resource/pip.rb
+++ b/lib/itamae/plugin/resource/pip.rb
@@ -7,7 +7,7 @@ module Itamae
         define_attribute :action, default: :install
         define_attribute :pip_binary, type: [String, Array], default: ['pip', '--disable-pip-version-check']
         define_attribute :package_name, type: String, default_name: true
-        define_attribute :options, type: [String, Array], default: :auto
+        define_attribute :options, type: [String, Array, Symbol], default: :auto
         define_attribute :version, type: String, default: false
 
         def pre_action


### PR DESCRIPTION
The default value of the options attribute is a symbol, but the type specification does not contain a symbol.
Therefore, if options is not specified, Itamae::Resource::InvalidTypeError will be raised at run time.