### PR TITLE
fix default value of options attribute

### DIFF
--- a/lib/itamae/plugin/resource/pip.rb
+++ b/lib/itamae/plugin/resource/pip.rb
@@ -7,7 +7,7 @@ module Itamae
         define_attribute :action, default: :install
         define_attribute :pip_binary, type: [String, Array], default: ['pip', '--disable-pip-version-check']
         define_attribute :package_name, type: String, default_name: true
-        define_attribute :options, type: [String, Array], default: :auto
+        define_attribute :options, type: [String, Array], default: false
         define_attribute :version, type: String, default: false
 
         def pre_action


### PR DESCRIPTION
The default value of options attribute is :auto.
Therefore, Itamae::Resource::InvalidTypeError is raised.