### PR TITLE
Accept package entry with filepath when parsing pip freeze output

### DIFF
--- a/itamae-plugin-resource-pip.gemspec
+++ b/itamae-plugin-resource-pip.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "serverspec"
 end

--- a/manifest.scm
+++ b/manifest.scm
@@ -1,0 +1,1 @@
+(specifications->manifest (list "python@3" "python-mkdocs" "ruby@3.1" "ruby-rspec" "itamae"))

--- a/spec/itamae-plugin-resource-pip/pip_spec.rb
+++ b/spec/itamae-plugin-resource-pip/pip_spec.rb
@@ -1,9 +1,0 @@
-require "spec_helper"
-
-describe file("/.pip/lib/python3.5/site-packages/tornado") do
-  it { should be_directory }
-end
-
-describe file("/.pip/lib/python3.5/site-packages/tornado-4.1.dist-info") do
-  it { should be_directory }
-end

--- a/spec/itamae/plugin/resource/pip_spec.rb
+++ b/spec/itamae/plugin/resource/pip_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe Itamae::Plugin::Resource::Pip do
+  describe "installed pips" do
+    it "name and version" do
+      output = double("output", stdout: "Babel==2.10.3")
+      backend = double("backend", run_command: output)
+      runner = double("runner", backend: backend)
+      recipe = double("recipe", runner: runner)
+      resource = Itamae::Plugin::Resource::Pip.new(recipe, "test-service")
+      expect(resource.send(:installed_pips)).to eq [{ name: "Babel", version: "2.10.3" }]
+    end
+  end
+end

--- a/spec/itamae/plugin/resource/pip_spec.rb
+++ b/spec/itamae/plugin/resource/pip_spec.rb
@@ -2,13 +2,19 @@ require "spec_helper"
 
 describe Itamae::Plugin::Resource::Pip do
   describe "installed pips" do
-    it "name and version" do
-      output = double("output", stdout: "Babel==2.10.3")
-      backend = double("backend", run_command: output)
-      runner = double("runner", backend: backend)
-      recipe = double("recipe", runner: runner)
-      resource = Itamae::Plugin::Resource::Pip.new(recipe, "test-service")
-      expect(resource.send(:installed_pips)).to eq [{ name: "Babel", version: "2.10.3" }]
+    let(:backend) { double("backend", run_command: output) }
+    let(:runner) { double("runner", backend: backend) }
+    let(:recipe) { double("recipe", runner: runner) }
+    let(:resource) { Itamae::Plugin::Resource::Pip.new(recipe, "test-service") }
+
+    context "with name and version" do
+      let(:output) { double("output", stdout: "Babel==2.10.3") }
+      it { expect(resource.send(:installed_pips)).to eq [{ name: "Babel", version: "2.10.3" }] }
+    end
+
+    context "with name and file" do
+      let(:output) { double("output", stdout: "importlib-metadata @ file:///tmp/guix-build-python-importlib-metadata-5.2.0.drv-0/importlib_metadata-5.2.0/dist/importlib_metadata-5.2.0-py3-none-any.whl") }
+      it { expect(resource.send(:installed_pips)).to eq [{ name: "importlib-metadata" }] }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,0 @@
-require 'serverspec'
-
-set :backend, :exec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require "itamae"
+require_relative "../lib/itamae/plugin/resource/pip"


### PR DESCRIPTION
Hello,

This change enables to accept a package entry with its filepath when parsing the pip freeze output.  Please see the following exerpt (`<package-name> @ <file-path>` line.)

```sh
pip3 freeze
# Babel==2.10.3
# click==8.1.3
# ghp-import==2.0.2
# importlib-metadata @ file:///tmp/guix-build-python-importlib-metadata-5.2.0.drv-0/importlib_metadata-5.2.0/dist/importlib_metadata-5.2.0-py3-none-any.whl <- fails to parse currently
# Jinja2==3.1.1
# ...
```

Also, non-portable integration tests are removed and the Guix manifest is added.

Regards,